### PR TITLE
Apply missing polyfill for AbortController

### DIFF
--- a/typescript/src/document.ts
+++ b/typescript/src/document.ts
@@ -1,5 +1,6 @@
 import type { ReadStream } from 'fs';
 
+import AbortController from 'abort-controller';
 import EventEmitter from 'eventemitter3';
 import FormData from 'form-data';
 import type { Readable } from 'readable-stream';


### PR DESCRIPTION
Apply polyfill for `AbortController` even in document.ts. See also: https://github.com/MortyDAO/mortyNFT/pull/46#issuecomment-1064821115

I checked recent changes of this repo and I found that the polyfill wasn't applied in the original already (maybe unintentionally).

First I tested on local Hyde admin console before applying this fix, and I confirmed the error is reproduced. Then I applied the fix and I confirmed the error is gone.

I also confirmed that there are no other unuse of the polyfill.
